### PR TITLE
optional use_dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Other options that you can set include:
  * **requested_for**: the vRA login ID to list as the owner of this resource. Defaults to the vRA username configured in the `driver` section.
  * **subtenant_id**: the Business Group ID to list as the owner. This is required if the catalog item is a shared/global item; we are unable to determine the subtenant_id from the catalog, and vRA requires it to be set on every request.
  * **private_key_path**: path to the SSH private key to use when logging in. Defaults to '~/.ssh/id_rsa' or '~/.ssh/id_dsa', preferring the RSA key. Only applies to instances where SSH transport is used (i.e. does not apply to Windows hosts with the WinRM transport configured).
+ * **use_dns**: Defaults to `false`.  Set to `true` if vRA doesn't manage vm ip addresses.  This will cause kitchen to attempt to connect via hostname.
 
 These settings can be set globally under the top-level `driver` section, or they can be set on each platform, which allows you to set globals and then override them. For example, this configuration would set the CPU count to 1 except on the "large" platform:
 

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -50,6 +50,7 @@ module Kitchen
           file if File.exist?(file)
         end.compact.first
       end
+      default_config :use_dns, false
 
       def name
         'vRA'
@@ -60,11 +61,16 @@ module Kitchen
 
         server = request_server
         state[:resource_id] = server.id
-
-        ip_address = server.ip_addresses.first
-        raise 'No IP address returned for the vRA request' if ip_address.nil?
-        state[:hostname] = server.ip_addresses.first
-        state[:ssh_key]  = config[:private_key_path] unless config[:private_key_path].nil?
+        if config[:use_dns]
+          dns_name = server.name
+          raise 'No server name returned for the vRA request' if dns_name.nil?
+          state[:hostname] = server.name
+        else
+          ip_address = server.ip_addresses.first
+          raise 'No IP address returned for the vRA request' if ip_address.nil?
+          state[:hostname] = server.ip_addresses.first
+        end
+        state[:ssh_key] = config[:private_key_path] unless config[:private_key_path].nil?
 
         wait_for_server(state, server)
         info("Server #{server.id} (#{server.name}) ready.")

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -62,12 +62,10 @@ module Kitchen
         server = request_server
         state[:resource_id] = server.id
         if config[:use_dns]
-          dns_name = server.name
-          raise 'No server name returned for the vRA request' if dns_name.nil?
+          raise 'No server name returned for the vRA request' if server.name.nil?
           state[:hostname] = server.name
         else
-          ip_address = server.ip_addresses.first
-          raise 'No IP address returned for the vRA request' if ip_address.nil?
+          raise 'No IP address returned for the vRA request' if server.ip_addresses.first.nil?
           state[:hostname] = server.ip_addresses.first
         end
         state[:ssh_key] = config[:private_key_path] unless config[:private_key_path].nil?

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -127,27 +127,6 @@ describe Kitchen::Driver::Vra do
       end
     end
 
-    describe 'getting the IP address from the server when use_dns is true' do
-      context 'when no IP addresses are returned' do
-        let(:config) do
-          {
-            use_dns: true
-          }
-        end
-        it 'returns hostname if use_dns is true' do
-          allow(resource).to receive(:ip_addresses).and_return([])
-          driver.create(state)
-          expect(state[:hostname]).to eq('server1')
-        end
-      end
-      context 'when IP addresses are returned' do
-        it 'sets the IP address as the hostname in the state hash' do
-          driver.create(state)
-          expect(state[:hostname]).to eq('1.2.3.4')
-        end
-      end
-    end
-
     it 'waits for the server to be ready' do
       expect(driver).to receive(:wait_for_server)
       driver.create(state)

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -41,7 +41,8 @@ describe Kitchen::Driver::Vra do
       requested_for: 'override_user@corp.local',
       notes:         'some notes',
       subtenant_id:  '160b473a-0ec9-473d-8156-28dd96c0b6b7',
-      lease_days:    5
+      lease_days:    5,
+      use_dns:       false
     }
   end
 
@@ -102,14 +103,34 @@ describe Kitchen::Driver::Vra do
       expect(state[:resource_id]).to eq('e8706351-cf4c-4c12-acb7-c90cc683b22c')
     end
 
-    describe 'getting the IP address from the server' do
+    describe 'getting the IP address from the server when use_dns is false' do
       context 'when no IP addresses are returned' do
         it 'raises an exception' do
           allow(resource).to receive(:ip_addresses).and_return([])
           expect { driver.create(state) }.to raise_error(RuntimeError)
         end
       end
+      context 'when IP addresses are returned' do
+        it 'sets the IP address as the hostname in the state hash' do
+          driver.create(state)
+          expect(state[:hostname]).to eq('1.2.3.4')
+        end
+      end
+    end
 
+    describe 'getting the IP address from the server when use_dns is true' do
+      context 'when no IP addresses are returned' do
+        let(:config) do
+          {
+            use_dns: true
+          }
+        end
+        it 'returns hostname if use_dns is true' do
+          allow(resource).to receive(:ip_addresses).and_return([])
+          driver.create(state)
+          expect(state[:hostname]).to eq('server1')
+        end
+      end
       context 'when IP addresses are returned' do
         it 'sets the IP address as the hostname in the state hash' do
           driver.create(state)

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -103,15 +103,24 @@ describe Kitchen::Driver::Vra do
       expect(state[:resource_id]).to eq('e8706351-cf4c-4c12-acb7-c90cc683b22c')
     end
 
-    describe 'getting the IP address from the server when use_dns is false' do
-      context 'when no IP addresses are returned' do
-        it 'raises an exception' do
+    describe 'setting the hostname in the state hash' do
+      context 'when use_dns is true' do
+        let(:config) { { use_dns: true } }
+        it 'raises an exception if the server name is nil' do
+          allow(resource).to receive(:name).and_return(nil)
+          expect { driver.create(state) }.to raise_error(RuntimeError)
+        end
+        it 'uses the server name as the hostname' do
+          driver.create(state)
+          expect(state[:hostname]).to eq('server1')
+        end
+      end
+      context 'when use_dns is false' do
+        it 'raises an exception if no IP address is available' do
           allow(resource).to receive(:ip_addresses).and_return([])
           expect { driver.create(state) }.to raise_error(RuntimeError)
         end
-      end
-      context 'when IP addresses are returned' do
-        it 'sets the IP address as the hostname in the state hash' do
+        it 'uses the IP address as the hostname' do
           driver.create(state)
           expect(state[:hostname]).to eq('1.2.3.4')
         end


### PR DESCRIPTION
As per the discussion with @adamleff in #2 here's a PR with the use_dns functionality.  This solves the use case I had, where my corporate vRA does not manage the IP addresses of vm's, but the `server.name` value was being pushed to DNS.

`use_dns` has been added with a default value of `false`.  When `false` kitchen-vra will stop if vRA does not supply an ip address.  When `true` kitchen-vra will insert the `server.name` value as the `state[:hostname]` only if an ip address is not returned by vRA.  If an ip address is returned, and `use_dns` is `true` the ip address will still be passed to `state[:hostname]`.

spec/vra_spec.rb has been updated with new tests which (I believe) should cover these changes.  I've also updated the description on the existing tests around ip to clarify that they are with `use_dns` set to the default of `false`.
