### PR TITLE
Adding sleep-before-ready config, and better failback for hostname.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Other options that you can set include:
 
  * **lease_days**: number of days to request for a lease, if your catalog item / blueprint requires it
  * **request_timeout**: amount of time, in seconds, to wait for a vRA request to complete. Default is 600 seconds.
+ * **server_ready_sleep_time**: amount of time, in seconds, to wait for Test Kitchen to check to see if the vRA instance is ready. This may be helpful if your provisioning environment has race conditions, such as DNS propagation, that might make Test Kitchen throw an exception. Defaults to nil.
  * **cpus**: number of CPUs the host should have
  * **memory**: amount of RAM, in MB, the host should have
  * **requested_for**: the vRA login ID to list as the owner of this resource. Defaults to the vRA username configured in the `driver` section.


### PR DESCRIPTION
In some environments, a race condition can exist between when a vRA
instance is provisioned to when it is actually ready. Such a race
condition may be DNS propagation. In the event of a NXDOMAIN when
TK looks up a hostname, it will cause TK to throw an exception
rather than waiting and trying again (as TK assumes a DNS failure
is unrecoverable). The `server_ready_sleep_time` allows users to
configure a sleep time before TK checks to see if the host is ready.
This is a hack, but it's an easy one.

Additionally, when `use_dns` is false, the vRA driver will still
fallback to the hostname in the event an IP address is not found.
This avoids the user needing to set use_dns to true in their
environment in these cases.