### PR TITLE
Allow `gem build` from downloaded zip file

### DIFF
--- a/kitchen-vra.gemspec
+++ b/kitchen-vra.gemspec
@@ -13,7 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef-partners/kitchen-vra'
   spec.license       = 'Apache 2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  file_list = if system('git rev-parse --git-dir 2>/dev/null')
+                `git ls-files -z`.split("\x0")
+              else
+                Dir['**/*']
+              end
+  spec.files         = file_list
   spec.executables   = []
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -94,7 +94,7 @@ module Kitchen
 
         servers = submitted_request.resources.select(&:vm?)
         raise 'The vRA request created more than one server. The catalog blueprint should only return one.' if servers.size > 1
-        raise 'the vRA request did not create any servers.' if servers.size == 0
+        raise 'the vRA request did not create any servers.' if servers.empty?
 
         servers.first
       end

--- a/lib/kitchen/driver/vra_version.rb
+++ b/lib/kitchen/driver/vra_version.rb
@@ -18,6 +18,6 @@
 
 module Kitchen
   module Driver
-    VRA_VERSION = '1.3.0'.freeze
+    VRA_VERSION = '1.3.1'.freeze
   end
 end


### PR DESCRIPTION
This PR does the following:

* Uses `Dir['**/*']` to collect files to include in the `.gem` file when `git ls-files` is unavailable (such as when one has downloaded the zip file due to environmental restrictions on `git`)
* Fixes a `rubocop` complaint
* Bumps a minor version number