### PR TITLE
Add support for a DNS suffix appended to server.name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,8 @@ Metrics/ClassLength:
 Metrics/LineLength:
   Max: 130
 Metrics/MethodLength:
+  Exclude:
+    - spec/vra_spec.rb
   Max: 25
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+AllCops:
+  DisplayCopNames: true
 Metrics/AbcSize:
   Max: 50
 Metrics/ClassLength:
@@ -5,8 +7,6 @@ Metrics/ClassLength:
 Metrics/LineLength:
   Max: 130
 Metrics/MethodLength:
-  Exclude:
-    - spec/vra_spec.rb
   Max: 25
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,6 @@ Style/SignalException:
   Enabled: false
 Style/SpaceInsideBrackets:
   Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 sudo: false
 
 rvm:
-- 2.0.0
 - 2.1
 - 2.2
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Other options that you can set include:
  * **subtenant_id**: the Business Group ID to list as the owner. This is required if the catalog item is a shared/global item; we are unable to determine the subtenant_id from the catalog, and vRA requires it to be set on every request.
  * **private_key_path**: path to the SSH private key to use when logging in. Defaults to '~/.ssh/id_rsa' or '~/.ssh/id_dsa', preferring the RSA key. Only applies to instances where SSH transport is used; i.e., does not apply to Windows hosts with the WinRM transport configured.
  * **use_dns**: Defaults to `false`.  Set to `true` if vRA doesn't manage vm ip addresses.  This will cause kitchen to attempt to connect via hostname.
- * **dns_suffix**: Defaults to `nil`.  Set to your domain suffix, for example 'mydomain.com'.  This only takes effect when `use_dns` == true.
+ * **dns_suffix**: Defaults to `nil`.  Set to your domain suffix, for example 'mydomain.com'.  This only takes effect when `use_dns` == true and is appended to the hostname returned by vRA.
  * **extra_parameters**: a hash of other data to set on a catalog request, most notably custom properties. Allows updates to existing properties on the blueprint as well as the addition of new properties. The vRA REST API expects 'provider-' appended to the front of a property name; each key in the hash is the property name, and the value is a another hash containing the value data type and the value itself.
 
 These settings can be set globally under the top-level `driver` section, or they can be set on each platform, which allows you to set globals and then override them. For example, this configuration would set the CPU count to 1 except on the "large" platform:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Other options that you can set include:
  * **subtenant_id**: the Business Group ID to list as the owner. This is required if the catalog item is a shared/global item; we are unable to determine the subtenant_id from the catalog, and vRA requires it to be set on every request.
  * **private_key_path**: path to the SSH private key to use when logging in. Defaults to '~/.ssh/id_rsa' or '~/.ssh/id_dsa', preferring the RSA key. Only applies to instances where SSH transport is used; i.e., does not apply to Windows hosts with the WinRM transport configured.
  * **use_dns**: Defaults to `false`.  Set to `true` if vRA doesn't manage vm ip addresses.  This will cause kitchen to attempt to connect via hostname.
+ * **dns_suffix**: Defaults to `nil`.  Set to your domain suffix, for example 'mydomain.com'.  This only takes effect when `use_dns` == true.
  * **extra_parameters**: a hash of other data to set on a catalog request, most notably custom properties. Allows updates to existing properties on the blueprint as well as the addition of new properties. The vRA REST API expects 'provider-' appended to the front of a property name; each key in the hash is the property name, and the value is a another hash containing the value data type and the value itself.
 
 These settings can be set globally under the top-level `driver` section, or they can be set on each platform, which allows you to set globals and then override them. For example, this configuration would set the CPU count to 1 except on the "large" platform:

--- a/kitchen-vra.gemspec
+++ b/kitchen-vra.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen'
-  spec.add_dependency 'vmware-vra',   '~> 2'
+  spec.add_dependency 'vmware-vra', '~> 2'
 
   spec.add_development_dependency 'bundler',   '~> 1.7'
   spec.add_development_dependency 'rake',      '~> 10.0'

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -52,6 +52,7 @@ module Kitchen
         end.compact.first
       end
       default_config :use_dns, false
+      default_config :dns_suffix, nil
 
       def name
         'vRA'
@@ -72,7 +73,7 @@ module Kitchen
       def hostname_for(server)
         if config[:use_dns]
           raise 'No server name returned for the vRA request' if server.name.nil?
-          return server.name
+          return config[:dns_suffix] ? "#{server.name}.#{config[:dns_suffix]}" : server.name
         end
 
         ip_address = server.ip_addresses.first

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -22,7 +22,7 @@ require 'kitchen/provisioner/dummy'
 require 'kitchen/transport/dummy'
 require 'kitchen/verifier/dummy'
 
-describe Kitchen::Driver::Vra do
+describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
   let(:platform)      { Kitchen::Platform.new(name: 'fake_platform') }
@@ -51,8 +51,7 @@ describe Kitchen::Driver::Vra do
                     logger:    logger,
                     transport: transport,
                     platform:  platform,
-                    to_str:    'instance_str'
-                   )
+                    to_str:    'instance_str')
   end
 
   before do
@@ -69,7 +68,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#create' do
+  describe '#create' do # rubocop:disable Metrics/MethodLength
     context 'when the server is already created' do
       let(:state) { { resource_id: '48959518-6a0d-46e1-8415-3749696b65f4' } }
 
@@ -115,7 +114,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#hostname_for' do
+  describe '#hostname_for' do # rubocop:disable Metrics/MethodLength
     let(:server) do
       double('server',
              id: 'test_id',
@@ -163,7 +162,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#request_server' do
+  describe '#request_server' do # rubocop:disable Metrics/MethodLength
     let(:submitted_request) { double('submitted_request') }
     let(:catalog_request)   { double('catalog_request') }
     let(:resource1) do
@@ -234,7 +233,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#wait_for_server' do
+  describe '#wait_for_server' do # rubocop:disable Metrics/MethodLength
     let(:connection) { instance.transport.connection(state) }
     let(:state)      { {} }
     let(:resource1) do
@@ -328,7 +327,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#destroy' do
+  describe '#destroy' do # rubocop:disable Metrics/MethodLength
     let(:resource_id)     { '8c1a833a-5844-4100-b58c-9cab3543c958' }
     let(:state)           { { resource_id: resource_id } }
     let(:vra_client)      { double('vra_client') }
@@ -391,7 +390,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#catalog_request' do
+  describe '#catalog_request' do # rubocop:disable Metrics/MethodLength
     let(:catalog_request) { double('catalog_request') }
     let(:vra_client)      { double('vra_client') }
     let(:catalog)         { double('catalog') }
@@ -452,8 +451,7 @@ describe Kitchen::Driver::Vra do
           cpus:          2,
           memory:        2048,
           extra_parameters: { 'key1' => { type: 'string', value: 'value1' },
-                              'key2' => { type: 'integer', value: 123 }
-                            }
+                              'key2' => { type: 'integer', value: 123 } }
         }
       end
 
@@ -476,7 +474,7 @@ describe Kitchen::Driver::Vra do
     end
   end
 
-  describe '#wait_for_request' do
+  describe '#wait_for_request' do # rubocop:disable Metrics/MethodLength
     before do
       # don't actually sleep
       allow(driver).to receive(:sleep)

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -124,6 +124,19 @@ describe Kitchen::Driver::Vra do
              vm?: true)
     end
 
+    context 'when use_dns is true and dns_suffix is defined' do
+      let(:config) do
+        {
+          use_dns:      true,
+          dns_suffix:   'my.com'
+        }
+      end
+
+      it 'returns the server name with suffix appended' do
+        expect(driver.hostname_for(server)).to eq('test_hostname.my.com')
+      end
+    end
+
     context 'when use_dns is true' do
       let(:config) { { use_dns: true } }
 

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -22,7 +22,6 @@ require 'kitchen/provisioner/dummy'
 require 'kitchen/transport/dummy'
 require 'kitchen/verifier/dummy'
 
-# rubocop:disable Metrics/MethodLength
 describe Kitchen::Driver::Vra do
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -22,7 +22,8 @@ require 'kitchen/provisioner/dummy'
 require 'kitchen/transport/dummy'
 require 'kitchen/verifier/dummy'
 
-describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/MethodLength
+describe Kitchen::Driver::Vra do
   let(:logged_output) { StringIO.new }
   let(:logger)        { Logger.new(logged_output) }
   let(:platform)      { Kitchen::Platform.new(name: 'fake_platform') }
@@ -68,7 +69,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#create' do # rubocop:disable Metrics/MethodLength
+  describe '#create' do
     context 'when the server is already created' do
       let(:state) { { resource_id: '48959518-6a0d-46e1-8415-3749696b65f4' } }
 
@@ -114,7 +115,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#hostname_for' do # rubocop:disable Metrics/MethodLength
+  describe '#hostname_for' do
     let(:server) do
       double('server',
              id: 'test_id',
@@ -162,7 +163,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#request_server' do # rubocop:disable Metrics/MethodLength
+  describe '#request_server' do
     let(:submitted_request) { double('submitted_request') }
     let(:catalog_request)   { double('catalog_request') }
     let(:resource1) do
@@ -233,7 +234,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#wait_for_server' do # rubocop:disable Metrics/MethodLength
+  describe '#wait_for_server' do
     let(:connection) { instance.transport.connection(state) }
     let(:state)      { {} }
     let(:resource1) do
@@ -327,7 +328,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#destroy' do # rubocop:disable Metrics/MethodLength
+  describe '#destroy' do
     let(:resource_id)     { '8c1a833a-5844-4100-b58c-9cab3543c958' }
     let(:state)           { { resource_id: resource_id } }
     let(:vra_client)      { double('vra_client') }
@@ -390,7 +391,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#catalog_request' do # rubocop:disable Metrics/MethodLength
+  describe '#catalog_request' do
     let(:catalog_request) { double('catalog_request') }
     let(:vra_client)      { double('vra_client') }
     let(:catalog)         { double('catalog') }
@@ -474,7 +475,7 @@ describe Kitchen::Driver::Vra do # rubocop:disable Metrics/MethodLength
     end
   end
 
-  describe '#wait_for_request' do # rubocop:disable Metrics/MethodLength
+  describe '#wait_for_request' do
     before do
       # don't actually sleep
       allow(driver).to receive(:sleep)


### PR DESCRIPTION
Occasionally DNS is fickle and vRA hands a hostname back to kitchen that isn't resolvable.  Appending a DNS suffix to the name appears to mitigate this issue.