### PR TITLE
Switched to using set_parameters

### DIFF
--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -203,7 +203,7 @@ module Kitchen
         catalog_request.subtenant_id  = config[:subtenant_id]  unless config[:subtenant_id].nil?
 
         config[:extra_parameters].each do |key, value_data|
-          catalog_request.set_parameter(key, value_data[:type], value_data[:value])
+          catalog_request.set_parameters(key, value_data)
         end
 
         catalog_request


### PR DESCRIPTION
### Description

Changed the method that is setting the extra parameters to support child object properties being set.  Ties into the changes made in https://github.com/chef-partners/vmware-vra-gem/pull/50

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
