### PR TITLE
Kitchen vRA enahancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [2.4.0] (https://github.com/chef-partners/kitchen-vra/tree/v2.4.0) (2018-01-04)
+[Full Changelog](https://github.com/chef-partners/kitchen-vra/compare/v2.3.0...2.4.0)
+
+**Enhanced/Fixed:**
+
+- Enhance vRA Kitchen driver to accept Catalog name as an input.
+- Ability of vRA Kitchen driver to accept credentials from environment variable even if they are not being mentioned in the `.kitchen.yml` file 
+- Ability of vRA kitchen driver to prompt for credentials if it’s not able retrieve from `.kitchen.yml` or from environment variable.
+- An option to not save credentials based on the usage of an existing flag.
+- Fixed a bug in the encryption/decryption logic.
+
+
 ## [2.3.0](https://github.com/chef-partners/kitchen-vra/tree/2.3.0) (2017-07-14)
 [Full Changelog](https://github.com/chef-partners/kitchen-vra/compare/v2.2.0...2.3.0)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,22 @@ driver:
   verify_ssl: true
 ```
 
-Then configure your platforms. A catalog_id is required for each platform:
+If you want username and password to be prompted, remove usename and password in your .kitchen.yml as shown below:
+
+```yaml
+driver:
+  name: vra
+  tenant: mytenant
+  base_url: https://vra.corp.local
+  verify_ssl: true
+```
+If you don't want to explicitly specify username and password in the kitchen.yml, you have an option to set it in the environment variable as 
+
+    $ export VRA_USER_NAME='myuser@corp.local'
+    $ export VRA_USER_PASSWORD='mypassword'
+
+Then configure your platforms. Either a catalog_id or a catalog_name is required for each platform. If both catalog_id and catalog_name are mentioned in .kitchen.yml then catalog_name would be used to derive the catalog_id and this catalog_id would override the catalog_id being passed in .kitchen.yml. In the below example as can be seen we are using catalog_id for centos6 driver while catalog_name for the centos7 driver just to demonstrate that we can use either of the two.
+
 
 ```yaml
 platforms:
@@ -45,8 +60,10 @@ platforms:
       catalog_id: e9db1084-d1c6-4c1f-8e3c-eb8f3dc574f9
   - name: centos7
     driver:
-      catalog_id: c4211950-ab07-42b1-ba80-8f5d3f2c8251
+      catalog_name: my_catalog_name
 ```
+
+
 
 Other options that you can set include:
 
@@ -72,6 +89,7 @@ driver:
 platforms:
   - name: small
     driver:
+      catalog_name: my_catalog_name_small
       catalog_id: 8a189191-fea6-43eb-981e-ee0fa40f8f57
       extra_parameters:
         provider-mycustompropname:
@@ -82,6 +100,7 @@ platforms:
           value: Non-Prod
   - name: large
     driver:
+      catalog_name: my_catalog_name_large
       catalog_id: 1d7c6122-18fa-4ed6-bd13-8a33b6c6ed50
       cpus: 2
       extra_parameters:

--- a/lib/kitchen/driver/vra_version.rb
+++ b/lib/kitchen/driver/vra_version.rb
@@ -19,6 +19,6 @@
 
 module Kitchen
   module Driver
-    VRA_VERSION = '2.3.0'
+    VRA_VERSION = '2.4.0'
   end
 end


### PR DESCRIPTION
### Description

Enhanced kitchen vRA driver with the following list of changes;
•	accept catalog_name as an input in kitchen.yml
•	accept credentials from environment variables
•	prompt users to enter credentials if not mentioned in kitchen.yml or not set in environment variables
•	save user credentials only if cache_credentials flag is set to true
•	fixed the bug in encryption/decryption logic to use separate initialization vector for user and password

### Issues Resolved

fixed the bug in encryption/decryption logic to use separate initialization vector for user and password


### Check List

- [Y] All tests pass.
- [Y] All style checks pass.
- [Y] Functionality includes testing.
- [Y] Functionality has been documented in the README if applicable
